### PR TITLE
Support more networks "from pretrained to DORY"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# QuantLib
+**QuantLib** is a library to train deploy quantised neural networks (QNNs).
+It was developed on top of the  [PyTorch](https://pytorch.org/) deep learning framework.
+
+QuantLib is a component of QuantLab, which also includes **organising software** to manage machine learning (ML) experiments (`systems` and `manager` packages, as well as the `main.py` façade script).
+
+## Installation and usage
+
+### Create an Anaconda environment and install `quantlib`
+
+Use [Anaconda](https://docs.anaconda.com/anaconda/install/) or Miniconda to install QuantLab's prerequisites.
+You can find a `quantlab.yml` at https://github.com/pulp-platform/quantlab/blob/main/quantlab.yml 
+```
+$ conda env create -f quantlab.yml
+```
+
+After creating the conda environment, install the `quantlib` quantisation library in your Anaconda environment:
+```
+$ conda activate quantlab
+(quantlab) $ cd quantlib
+(quantlab) $ python setup.py install
+(quantlab) $ cd ..
+```
+
+## Notice
+
+### Licensing information
+`quantlib` is distributed under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
+
+In case you are planning to use QuantLab and `quantlib` in your projects, you might also want to consider the licenses under which the packages on which they depend are distributed:
+
+* PyTorch - a [mix of licenses](https://github.com/pytorch/pytorch/blob/master/NOTICE), including the Apache 2.0 License and the 3-Clause BSD License;
+* TensorBoard - [Apache 2.0 License](https://github.com/tensorflow/tensorboard/blob/master/LICENSE);
+* NetworkX - [3-Clause BSD License](https://github.com/networkx/networkx/blob/main/LICENSE.txt);
+* GraphViz - [MIT License](https://github.com/graphp/graphviz/blob/master/LICENSE);
+* matplotlib - a [custom license](https://github.com/matplotlib/matplotlib/blob/master/LICENSE/LICENSE);
+* NumPy - [3-Clause BSD License](https://github.com/numpy/numpy/blob/main/LICENSE.txt);
+* SciPy - [3-Clause BSD License](https://github.com/scipy/scipy/blob/master/LICENSE.txt);
+* Mako - [MIT License](https://github.com/sqlalchemy/mako/blob/master/LICENSE);
+* Jupyter - [3-Clause BSD License](https://github.com/jupyter/notebook/blob/master/LICENSE).
+
+### Authors
+* Matteo Spallanzani <<a href="mailto:spmatteo@iis.ee.ethz.ch">spmatteo@iis.ee.ethz.ch</a>> (ETH Zurich, now at Axelera AI)
+* Georg Rutishauser  <<a href="mailto:georgr@iis.ee.ethz.ch">georgr@iis.ee.ethz.ch</a>> (ETH Zurich)
+* Moritz Scherer     <<a href="mailto:scheremo@iis.ee.ethz.ch">scheremo@iis.ee.ethz.ch</a>> (ETH Zurich)
+* Francesco Conti    <<a href="mailto:f.conti@unibo.it">f.conti@unibo.it</a>> (University of Bologna)

--- a/__init__.py
+++ b/__init__.py
@@ -4,7 +4,7 @@
 # Author(s):
 # Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
 # 
-# Copyright (c) 2020-2022 ETH Zurich.
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/algorithms/__init__.py
+++ b/algorithms/__init__.py
@@ -1,2 +1,21 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from . import qbase
 from .qcontrollers import Controller

--- a/algorithms/qalgorithms/__init__.py
+++ b/algorithms/qalgorithms/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from collections import OrderedDict
 
 from .modulemapping import ModuleMapping

--- a/algorithms/qalgorithms/modulemapping/__init__.py
+++ b/algorithms/qalgorithms/modulemapping/__init__.py
@@ -1,1 +1,20 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .modulemapping import ModuleMapping

--- a/algorithms/qalgorithms/modulemapping/modulemapping.py
+++ b/algorithms/qalgorithms/modulemapping/modulemapping.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from collections import OrderedDict
 import torch.nn as nn
 from typing import Type

--- a/algorithms/qalgorithms/ptqalgorithms/__init__.py
+++ b/algorithms/qalgorithms/ptqalgorithms/__init__.py
@@ -1,0 +1,18 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 

--- a/algorithms/qalgorithms/qatalgorithms/__init__.py
+++ b/algorithms/qalgorithms/qatalgorithms/__init__.py
@@ -1,0 +1,18 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 

--- a/algorithms/qalgorithms/qatalgorithms/inq/__init__.py
+++ b/algorithms/qalgorithms/qatalgorithms/inq/__init__.py
@@ -1,0 +1,18 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 

--- a/algorithms/qalgorithms/qatalgorithms/pact/__init__.py
+++ b/algorithms/qalgorithms/qatalgorithms/pact/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from quantlib.algorithms.qalgorithms import ModuleMapping
 
 from .qactivations import NNMODULE_TO_PACTACTIVATION, PACTIdentity, PACTReLU, PACTReLU6, PACTLeakyReLU

--- a/algorithms/qalgorithms/qatalgorithms/pact/lib/__init__.py
+++ b/algorithms/qalgorithms/qatalgorithms/pact/lib/__init__.py
@@ -1,2 +1,21 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .autograd_quantiser import _PACTQuantiser
 from .autograd_redirectcliphi import _PACTRedirectClipHiGrad

--- a/algorithms/qalgorithms/qatalgorithms/pact/lib/autograd_quantiser.py
+++ b/algorithms/qalgorithms/qatalgorithms/pact/lib/autograd_quantiser.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch
 from typing import Tuple
 

--- a/algorithms/qalgorithms/qatalgorithms/pact/lib/autograd_redirectcliphi.py
+++ b/algorithms/qalgorithms/qatalgorithms/pact/lib/autograd_redirectcliphi.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch
 from typing import Tuple
 

--- a/algorithms/qalgorithms/qatalgorithms/pact/qactivations.py
+++ b/algorithms/qalgorithms/qatalgorithms/pact/qactivations.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch
 import torch.nn as nn
 

--- a/algorithms/qalgorithms/qatalgorithms/pact/qlinears.py
+++ b/algorithms/qalgorithms/qatalgorithms/pact/qlinears.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch
 import torch.nn as nn
 from typing import Tuple

--- a/algorithms/qalgorithms/qatalgorithms/pact/qmodules.py
+++ b/algorithms/qalgorithms/qatalgorithms/pact/qmodules.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from enum import Enum, auto
 import torch
 import torch.nn as nn

--- a/algorithms/qalgorithms/qatalgorithms/pact_test.py
+++ b/algorithms/qalgorithms/qatalgorithms/pact_test.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import unittest
 import torch
 import torch.nn as nn

--- a/algorithms/qalgorithms/qatalgorithms/ste/__init__.py
+++ b/algorithms/qalgorithms/qatalgorithms/ste/__init__.py
@@ -1,0 +1,18 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 

--- a/algorithms/qalgorithms/qatalgorithms/tqt/__init__.py
+++ b/algorithms/qalgorithms/qatalgorithms/tqt/__init__.py
@@ -1,0 +1,18 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 

--- a/algorithms/qalgorithms/qatalgorithms/tqt/lib/__init__.py
+++ b/algorithms/qalgorithms/qatalgorithms/tqt/lib/__init__.py
@@ -1,0 +1,18 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 

--- a/algorithms/qalgorithms/qatalgorithms/tqt/lib/autograd_tqt.py
+++ b/algorithms/qalgorithms/qatalgorithms/tqt/lib/autograd_tqt.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch
 from typing import Tuple
 

--- a/algorithms/qalgorithms/qatalgorithms/tqt/ops.py
+++ b/algorithms/qalgorithms/qatalgorithms/tqt/ops.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch
 import torch.nn as nn
 from typing import Tuple, Dict, Union

--- a/algorithms/qbase/__init__.py
+++ b/algorithms/qbase/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .qrange import QRange
 from .qrange import QRangeSpecType, resolve_qrangespec
 from .qhparams import create_qhparams

--- a/algorithms/qbase/observer/__init__.py
+++ b/algorithms/qbase/observer/__init__.py
@@ -1,2 +1,21 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .observers import TensorObserver
 from .observers import MinMaxMeanVarObserver

--- a/algorithms/qbase/observer/observers.py
+++ b/algorithms/qbase/observer/observers.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from functools import reduce
 from operator import mul
 import torch

--- a/algorithms/qbase/observer/statistics.py
+++ b/algorithms/qbase/observer/statistics.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from dataclasses import dataclass
 import torch
 from typing import Any

--- a/algorithms/qbase/observer_test.py
+++ b/algorithms/qbase/observer_test.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import unittest
 import torch
 

--- a/algorithms/qbase/qgranularity/__init__.py
+++ b/algorithms/qbase/qgranularity/__init__.py
@@ -1,2 +1,21 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .qgranularity import QGranularity
 from .qgranularity import QGranularitySpecType, resolve_qgranularityspec

--- a/algorithms/qbase/qgranularity/qgranularity.py
+++ b/algorithms/qbase/qgranularity/qgranularity.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from enum import Enum
 from typing import Tuple, Union, NewType
 

--- a/algorithms/qbase/qgranularity_test.py
+++ b/algorithms/qbase/qgranularity_test.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import unittest
 
 from .qgranularity import resolve_qgranularityspec

--- a/algorithms/qbase/qhparams/__init__.py
+++ b/algorithms/qbase/qhparams/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .qhparams import create_qhparams
 from .qhparams import get_zero_scale, get_scale
 from .qhparams import get_clipping_bounds

--- a/algorithms/qbase/qhparams/qhparams.py
+++ b/algorithms/qbase/qhparams/qhparams.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 """Handle the interchangeability of offsets, quanta, and clipping bounds.
 
 Given a quantiser, its offset :math:`z`, quantum :math:`\varepsilon` and

--- a/algorithms/qbase/qhparams_test.py
+++ b/algorithms/qbase/qhparams_test.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import unittest
 import torch
 

--- a/algorithms/qbase/qhparamsinitstrategy/__init__.py
+++ b/algorithms/qbase/qhparamsinitstrategy/__init__.py
@@ -1,2 +1,21 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .qhparamsinitstrategy import QHParamsInitStrategy
 from .qhparamsinitstrategy import QHParamsInitStrategySpecType, resolve_qhparamsinitstrategyspec

--- a/algorithms/qbase/qhparamsinitstrategy/qhparamsinitstrategy.py
+++ b/algorithms/qbase/qhparamsinitstrategy/qhparamsinitstrategy.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from enum import Enum
 import inspect
 import torch

--- a/algorithms/qbase/qhparamsinitstrategy_test.py
+++ b/algorithms/qbase/qhparamsinitstrategy_test.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import unittest
 import torch
 

--- a/algorithms/qbase/qrange/__init__.py
+++ b/algorithms/qbase/qrange/__init__.py
@@ -1,2 +1,21 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .qrange import UNKNOWN, IMPLICIT_STEP, QRange
 from .qrange import QRangeSpecType, resolve_qrangespec

--- a/algorithms/qbase/qrange/qrange.py
+++ b/algorithms/qbase/qrange/qrange.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from enum import Enum
 from typing import Tuple, Dict
 from typing import Union

--- a/algorithms/qbase/qrange_test.py
+++ b/algorithms/qbase/qrange_test.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import unittest
 
 from quantlib.algorithms.qbase.qrange import resolve_qrangespec

--- a/algorithms/qcontrollers/__init__.py
+++ b/algorithms/qcontrollers/__init__.py
@@ -1,1 +1,20 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .controller import Controller

--- a/algorithms/qcontrollers/controller.py
+++ b/algorithms/qcontrollers/controller.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 class Controller(object):
 
     def __init__(self):

--- a/algorithms/qmodules/__init__.py
+++ b/algorithms/qmodules/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .qmodules import SUPPORTED_FPMODULES
 from .qmodules import QIdentity, QReLU, QReLU6, QLeakyReLU
 from .qmodules import QLinear, QConv1d, QConv2d, QConv3d

--- a/algorithms/qmodules/qmodules/__init__.py
+++ b/algorithms/qmodules/qmodules/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .qactivations import SUPPORTED_ACTIVATION_FPMODULES, QIdentity, QReLU, QReLU6, QLeakyReLU
 from .qlinears import SUPPORTED_LINEAR_FPMODULES, QLinear, QConv1d, QConv2d, QConv3d
 

--- a/algorithms/qmodules/qmodules/qactivations.py
+++ b/algorithms/qmodules/qmodules/qactivations.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from __future__ import annotations
 import torch
 import torch.nn as nn

--- a/algorithms/qmodules/qmodules/qlinears.py
+++ b/algorithms/qmodules/qmodules/qlinears.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from __future__ import annotations
 import torch
 import torch.nn as nn

--- a/algorithms/qmodules/qmodules/qmodules.py
+++ b/algorithms/qmodules/qmodules/qmodules.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from __future__ import annotations
 import torch
 import torch.nn as nn

--- a/algorithms/qmodules/qmodules_test.py
+++ b/algorithms/qmodules/qmodules_test.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from __future__ import annotations
 import unittest
 import torch

--- a/backends/__init__.py
+++ b/backends/__init__.py
@@ -1,1 +1,20 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from . import dory

--- a/backends/base/__init__.py
+++ b/backends/base/__init__.py
@@ -1,2 +1,21 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .onnxannotator import ONNXAnnotator
 from .onnxexporter import ONNXExporter

--- a/backends/base/onnxannotator.py
+++ b/backends/base/onnxannotator.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import os
 import torch.nn as nn
 import onnx

--- a/backends/base/onnxexporter.py
+++ b/backends/base/onnxexporter.py
@@ -13,6 +13,7 @@ class ONNXExporter(object):
         super(ONNXExporter, self).__init__()
         self._annotator = annotator
         self._onnxfilepath = None
+        self._onnxname = None
 
     def export(self,
                network:       nn.Module,
@@ -26,6 +27,7 @@ class ONNXExporter(object):
         onnxfilename = onnxname + '_QL_NOANNOTATION.onnx'  # TODO: should the name hint at whether the network is FP, FQ, or TQ? How can we derive this information (user-provided vs. inferred from the network)?
         onnxfilepath = os.path.join(path, onnxfilename)
         self._onnxfilepath = onnxfilepath
+        self._onnxname = onnxname
 
         # export the network (https://pytorch.org/docs/master/onnx.html#torch.onnx.export)
         torch.onnx.export(network,

--- a/backends/base/onnxexporter.py
+++ b/backends/base/onnxexporter.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import os
 import torch
 import torch.nn as nn

--- a/backends/base/onnxexporter.py
+++ b/backends/base/onnxexporter.py
@@ -2,6 +2,7 @@ import os
 import torch
 import torch.nn as nn
 from typing import Optional
+import warnings
 
 from .onnxannotator import ONNXAnnotator
 
@@ -29,13 +30,15 @@ class ONNXExporter(object):
         self._onnxfilepath = onnxfilepath
         self._onnxname = onnxname
 
-        # export the network (https://pytorch.org/docs/master/onnx.html#torch.onnx.export)
-        torch.onnx.export(network,
-                          torch.randn(input_shape),  # a dummy input to trace the `nn.Module`
-                          onnxfilepath,
-                          export_params=True,
-                          do_constant_folding=True,
-                          opset_version=opset_version)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            # export the network (https://pytorch.org/docs/master/onnx.html#torch.onnx.export)
+            torch.onnx.export(network,
+                            torch.randn(input_shape),  # a dummy input to trace the `nn.Module`
+                            onnxfilepath,
+                            export_params=True,
+                            do_constant_folding=True,
+                            opset_version=opset_version)
 
-        # annotate the ONNX model with backend-specific information
-        self._annotator.annotate(network, onnxfilepath)
+            # annotate the ONNX model with backend-specific information
+            self._annotator.annotate(network, onnxfilepath)

--- a/backends/dory/__init__.py
+++ b/backends/dory/__init__.py
@@ -1,1 +1,20 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .onnxexporter import DORYExporter

--- a/backends/dory/onnxannotator.py
+++ b/backends/dory/onnxannotator.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import numpy as np
 import torch.nn as nn
 import onnx

--- a/backends/dory/onnxexporter.py
+++ b/backends/dory/onnxexporter.py
@@ -23,7 +23,7 @@ class DORYExporter(ONNXExporter):
         name: str = "DEFAULT"
     ):
         
-        onnx_file = self._onnxfilepath
+        onnx_file = self._onnxfilepath.rsplit('.', 1)[0].rstrip('_NOANNOTATION') + '_DORY.onnx'  # TODO: generate the backend-annotated filename more elegantly
         name = self._onnxname
 
         cnn_dory_config = {
@@ -90,4 +90,5 @@ class DORYExporter(ONNXExporter):
         export_to_txt('input', 'input', x)
         for i, (module_name, f) in enumerate(features):
             export_to_txt(module_name, f"out_layer{i}", f)
+        export_to_txt('output', f"out_layer{len(features)}", y)
         export_to_txt('output', 'output', y)

--- a/backends/dory/onnxexporter.py
+++ b/backends/dory/onnxexporter.py
@@ -20,14 +20,12 @@ class DORYExporter(ONNXExporter):
         nb_inputs:  int = 1,
         input_bits: int = 8,
         input_signed: bool = True,
-        name = "DEFAULT"
         name: str = "DEFAULT",
         onnx_file: os.PathLike = self._onnxfilepath
     ):
 
         cnn_dory_config = {
             "BNRelu_bits": 32,
-            "onnx_file": self._onnxfilepath,
             "onnx_file": onnx_file,
             "code reserved space": code_size,
             "n_inputs": nb_inputs, # TODO retrieve this info from QL graph

--- a/backends/dory/onnxexporter.py
+++ b/backends/dory/onnxexporter.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from functools import partial
 import os
 import torch

--- a/backends/dory/onnxexporter.py
+++ b/backends/dory/onnxexporter.py
@@ -20,9 +20,10 @@ class DORYExporter(ONNXExporter):
         nb_inputs:  int = 1,
         input_bits: int = 8,
         input_signed: bool = True,
-        name: str = "DEFAULT",
-        onnx_file: os.PathLike = self._onnxfilepath
+        name: str = "DEFAULT"
     ):
+        
+        onnx_file = self._onnxfilepath
 
         cnn_dory_config = {
             "BNRelu_bits": 32,

--- a/backends/dory/onnxexporter.py
+++ b/backends/dory/onnxexporter.py
@@ -15,6 +15,7 @@ class DORYExporter(ONNXExporter):
 
         
     def export_json_config(
+        self,
         code_size:  int = 160000,
         nb_inputs:  int = 1,
         input_bits: int = 8,

--- a/backends/dory/onnxexporter.py
+++ b/backends/dory/onnxexporter.py
@@ -3,19 +3,17 @@ import os
 import torch
 import torch.nn as nn
 from typing import List, NamedTuple
-
 from .onnxannotator import DORYAnnotator
 from quantlib.backends.base import ONNXExporter
 import quantlib.editing.graphs as qg
 import json
 from pathlib import Path
-
 class DORYExporter(ONNXExporter):
-
     def __init__(self):
         annotator = DORYAnnotator()
         super(DORYExporter, self).__init__(annotator=annotator)
 
+    @staticmethod    
     def export_json_config(
         self,
         code_size:  int = 160000,
@@ -23,33 +21,31 @@ class DORYExporter(ONNXExporter):
         input_bits: int = 8,
         input_signed: bool = True,
         name = "DEFAULT"
+        name: str = "DEFAULT",
+        onnx_file: os.PathLike = self._onnxfilepath
     ):
 
         cnn_dory_config = {
             "BNRelu_bits": 32,
             "onnx_file": self._onnxfilepath,
+            "onnx_file": onnx_file,
             "code reserved space": code_size,
             "n_inputs": nb_inputs, # TODO retrieve this info from QL graph
             "input_bits": input_bits, # TODO retrieve this info from QL graph
             "input_signed": input_signed # TODO retrieve this info from QL graph
         }
-
         jsonfilepath = Path(self._onnxfilepath).parent
         with open(jsonfilepath.joinpath(f"config_{name}.json"), "w") as fp:
             json.dump(cnn_dory_config, fp, indent=4)
-
     @staticmethod
     def dump_features(network: nn.Module,
                       x:       torch.Tensor,
                       path:    os.PathLike) -> None:
         """Given a network, export the features associated with a given input.
-
         To verify the correctness of an ONNX export, DORY requires text files
         containing the values of the features for each layer in the target
         network. The format of these text files is exemplified here:
-
         https://github.com/pulp-platform/dory_examples/tree/master/examples/Quantlab_examples .
-
         """
 
         class Features(NamedTuple):

--- a/backends/dory/onnxexporter.py
+++ b/backends/dory/onnxexporter.py
@@ -15,7 +15,6 @@ class DORYExporter(ONNXExporter):
 
     @staticmethod    
     def export_json_config(
-        self,
         code_size:  int = 160000,
         nb_inputs:  int = 1,
         input_bits: int = 8,

--- a/backends/dory/onnxexporter.py
+++ b/backends/dory/onnxexporter.py
@@ -13,7 +13,7 @@ class DORYExporter(ONNXExporter):
         annotator = DORYAnnotator()
         super(DORYExporter, self).__init__(annotator=annotator)
 
-    @staticmethod    
+        
     def export_json_config(
         code_size:  int = 160000,
         nb_inputs:  int = 1,

--- a/backends/dory/onnxexporter.py
+++ b/backends/dory/onnxexporter.py
@@ -24,6 +24,7 @@ class DORYExporter(ONNXExporter):
     ):
         
         onnx_file = self._onnxfilepath
+        name = self._onnxname
 
         cnn_dory_config = {
             "BNRelu_bits": 32,

--- a/editing/__init__.py
+++ b/editing/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 """A namespace of abstractions to manipulate computational graphs.
 
 A computational graph is a directed acyclic graph (DAG) :math:`G` composed by two types of nodes:

--- a/editing/editing/__init__.py
+++ b/editing/editing/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from . import editors
 from . import float2fake as f2f
 from . import fake2true as f2t

--- a/editing/editing/debugger/__init__.py
+++ b/editing/editing/debugger/__init__.py
@@ -1,0 +1,18 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 

--- a/editing/editing/debugger/debugger.py
+++ b/editing/editing/debugger/debugger.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch.fx as fx
 import warnings
 from typing import NamedTuple, List, Union, Optional, NewType

--- a/editing/editing/debugger/subgraph.py
+++ b/editing/editing/debugger/subgraph.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch.fx as fx
 from torch.fx.experimental.optimization import extract_subgraph
 from typing import List

--- a/editing/editing/editors/__init__.py
+++ b/editing/editing/editors/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .base import Annotator
 from .base import ApplicationPoint, Finder, Applier, Rewriter
 from .base import ComposedEditor

--- a/editing/editing/editors/base/__init__.py
+++ b/editing/editing/editors/base/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 """This package implements the hierachy of base classes of QuantLib's graph
 editing machinery.
 

--- a/editing/editing/editors/base/annotator.py
+++ b/editing/editing/editors/base/annotator.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch.fx as fx
 
 from .baseeditor import BaseEditor, SymbolicTraceFnType

--- a/editing/editing/editors/base/baseeditor.py
+++ b/editing/editing/editors/base/baseeditor.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch.fx as fx
 
 from .editor import Editor

--- a/editing/editing/editors/base/baseeditor.py
+++ b/editing/editing/editors/base/baseeditor.py
@@ -12,7 +12,7 @@ class BaseEditor(Editor):
 
         super(BaseEditor, self).__init__()
 
-        self._id: str = '_'.join(['QL', name + f'[{str(id(self))}]'])  # we use this attribute to uniquely identify the edits made using this `Editor`
+        self._id: str = '_'.join(['QL', name + f'_{str(id(self))}_'])  # we use this attribute to uniquely identify the edits made using this `Editor`
         self._symbolic_trace_fn = symbolic_trace_fn                    # we assume that the `fx.GraphModule`s processed by this `Editor` have been obtained using this tracing function
 
     @property

--- a/editing/editing/editors/base/composededitor.py
+++ b/editing/editing/editors/base/composededitor.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch.fx as fx
 from typing import List
 

--- a/editing/editing/editors/base/editor.py
+++ b/editing/editing/editors/base/editor.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch.fx as fx
 
 

--- a/editing/editing/editors/base/rewriter/__init__.py
+++ b/editing/editing/editors/base/rewriter/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .applicationpoint import ApplicationPoint
 from .finder import Finder
 from .applier import Applier

--- a/editing/editing/editors/base/rewriter/applicationpoint.py
+++ b/editing/editing/editors/base/rewriter/applicationpoint.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from abc import ABC
 
 

--- a/editing/editing/editors/base/rewriter/applier.py
+++ b/editing/editing/editors/base/rewriter/applier.py
@@ -29,7 +29,7 @@ class Applier(object):
 
         # create a unique application identifier
         self._counter += 1
-        id_ = id_ + f'[{str(self._counter)}]'
+        id_ = id_ + f'_{str(self._counter)}_'
 
         # modify the graph
         g = self._apply(g, ap, id_)

--- a/editing/editing/editors/base/rewriter/applier.py
+++ b/editing/editing/editors/base/rewriter/applier.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch.fx as fx
 
 from .applicationpoint import ApplicationPoint

--- a/editing/editing/editors/base/rewriter/finder.py
+++ b/editing/editing/editors/base/rewriter/finder.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch.fx as fx
 from typing import List
 

--- a/editing/editing/editors/base/rewriter/rewriter.py
+++ b/editing/editing/editors/base/rewriter/rewriter.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from __future__ import annotations
 
 import torch.fx as fx

--- a/editing/editing/editors/nnmodules/__init__.py
+++ b/editing/editing/editors/nnmodules/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 """This package implements the abstractions required to rewrite ``fx.Graph``s
 obtained by tracing ``nn.Module``s.
 

--- a/editing/editing/editors/nnmodules/applicationpoint.py
+++ b/editing/editing/editors/nnmodules/applicationpoint.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from collections import OrderedDict
 import torch.fx as fx
 

--- a/editing/editing/editors/nnmodules/applier.py
+++ b/editing/editing/editors/nnmodules/applier.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch.fx as fx
 
 from ..base import Applier

--- a/editing/editing/editors/nnmodules/finder/__init__.py
+++ b/editing/editing/editors/nnmodules/finder/__init__.py
@@ -1,2 +1,21 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .nnsequential import PathGraphMatcher
 from .genericnnmodule import GenericGraphMatcher

--- a/editing/editing/editors/nnmodules/finder/base.py
+++ b/editing/editing/editors/nnmodules/finder/base.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch.fx as fx
 from typing import List
 

--- a/editing/editing/editors/nnmodules/finder/genericnnmodule.py
+++ b/editing/editing/editors/nnmodules/finder/genericnnmodule.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import networkx as nx
 import torch.fx as fx
 from typing import List

--- a/editing/editing/editors/nnmodules/finder/nnsequential.py
+++ b/editing/editing/editors/nnmodules/finder/nnsequential.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import warnings
 from collections import OrderedDict
 import torch.fx as fx

--- a/editing/editing/editors/nnmodules/pattern/__init__.py
+++ b/editing/editing/editors/nnmodules/pattern/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .base import NNModuleWithCheckers
 from .nnsequential import NNSequentialPattern, NNModuleDescription, Candidates, Roles, generate_named_patterns
 from .genericnnmodule import GenericNNModulePattern

--- a/editing/editing/editors/nnmodules/pattern/base/__init__.py
+++ b/editing/editing/editors/nnmodules/pattern/base/__init__.py
@@ -1,2 +1,21 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .nnmodulewithcheckers import Checker, NNModuleWithCheckers, NNModuleWithCheckersSpecType
 from .pattern import NNModulePattern

--- a/editing/editing/editors/nnmodules/pattern/base/nnmodulewithcheckers.py
+++ b/editing/editing/editors/nnmodules/pattern/base/nnmodulewithcheckers.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 """This module implements an abstraction to describe an ``nn.Module`` and
 rich semantic checks on its composing sub-modules.
 

--- a/editing/editing/editors/nnmodules/pattern/base/pattern.py
+++ b/editing/editing/editors/nnmodules/pattern/base/pattern.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from __future__ import annotations
 
 import torch.nn as nn

--- a/editing/editing/editors/nnmodules/pattern/genericnnmodule/__init__.py
+++ b/editing/editing/editors/nnmodules/pattern/genericnnmodule/__init__.py
@@ -1,1 +1,20 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .pattern import GenericNNModulePattern

--- a/editing/editing/editors/nnmodules/pattern/genericnnmodule/nxfxgraph.py
+++ b/editing/editing/editors/nnmodules/pattern/genericnnmodule/nxfxgraph.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from __future__ import annotations
 
 from collections import OrderedDict

--- a/editing/editing/editors/nnmodules/pattern/genericnnmodule/pattern.py
+++ b/editing/editing/editors/nnmodules/pattern/genericnnmodule/pattern.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from functools import partial
 import torch.fx as fx
 from typing import Callable, Dict

--- a/editing/editing/editors/nnmodules/pattern/nnsequential/__init__.py
+++ b/editing/editing/editors/nnmodules/pattern/nnsequential/__init__.py
@@ -1,2 +1,21 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .pattern import NNSequentialPattern
 from .factory import NNModuleDescription, Candidates, Roles, generate_named_patterns

--- a/editing/editing/editors/nnmodules/pattern/nnsequential/factory/__init__.py
+++ b/editing/editing/editors/nnmodules/pattern/nnsequential/factory/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 """This package implements abstractions to programmatically generate
 ``NNSequentialPattern``s.
 

--- a/editing/editing/editors/nnmodules/pattern/nnsequential/factory/candidates.py
+++ b/editing/editing/editors/nnmodules/pattern/nnsequential/factory/candidates.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from collections import OrderedDict
 import torch.nn as nn
 from typing import NamedTuple, Tuple, Dict, Union, Optional, Type, Any

--- a/editing/editing/editors/nnmodules/pattern/nnsequential/factory/factory.py
+++ b/editing/editing/editors/nnmodules/pattern/nnsequential/factory/factory.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from collections import OrderedDict
 import torch.nn as nn
 from typing import NamedTuple, List

--- a/editing/editing/editors/nnmodules/pattern/nnsequential/factory/roles.py
+++ b/editing/editing/editors/nnmodules/pattern/nnsequential/factory/roles.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from collections import OrderedDict
 import itertools
 from typing import Tuple

--- a/editing/editing/editors/nnmodules/pattern/nnsequential/pattern.py
+++ b/editing/editing/editors/nnmodules/pattern/nnsequential/pattern.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch.nn as nn
 import torch.fx as fx
 from typing import Set, Union

--- a/editing/editing/editors/nnmodules/rewriter/__init__.py
+++ b/editing/editing/editors/nnmodules/rewriter/__init__.py
@@ -1,2 +1,21 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .rewriter import NNModuleRewriter
 from .factory import get_rewriter_class

--- a/editing/editing/editors/nnmodules/rewriter/factory.py
+++ b/editing/editing/editors/nnmodules/rewriter/factory.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from typing import Union, Type
 
 from ..pattern import NNSequentialPattern, GenericNNModulePattern

--- a/editing/editing/editors/nnmodules/rewriter/rewriter.py
+++ b/editing/editing/editors/nnmodules/rewriter/rewriter.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from ..pattern.base import NNModulePattern
 from ..finder.base import NNModuleMatcher
 from ..applier import NNModuleApplier

--- a/editing/editing/editors/optrees/__init__.py
+++ b/editing/editing/editors/optrees/__init__.py
@@ -1,2 +1,21 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .applicationpoint import OpTree, OpSpec
 from .finder import OpTreeFinder

--- a/editing/editing/editors/optrees/applicationpoint.py
+++ b/editing/editing/editors/optrees/applicationpoint.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 """Some rewriting rules look for classes of patterns that it is unfeasible or
 simply not convenient to fully enumerate. In these cases, we replace pattern
 matching with specific algorithms that can capture any pattern that we are

--- a/editing/editing/editors/optrees/finder.py
+++ b/editing/editing/editors/optrees/finder.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch.fx as fx
 from typing import Tuple, List, Set
 

--- a/editing/editing/editors/retracers/__init__.py
+++ b/editing/editing/editors/retracers/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .retracer import Retracer
 from quantlib.editing.graphs.fx import quantlib_symbolic_trace
 

--- a/editing/editing/editors/retracers/retracer.py
+++ b/editing/editing/editors/retracers/retracer.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch.fx as fx
 
 from ..base import Annotator

--- a/editing/editing/editors/test_base.py
+++ b/editing/editing/editors/test_base.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import unittest
 import random
 import torch

--- a/editing/editing/fake2true/__init__.py
+++ b/editing/editing/fake2true/__init__.py
@@ -47,6 +47,7 @@ from .integerisation import F2TIntegeriser
 from .epstunnels import EpsTunnelConstructSimplifier
 from .epstunnels import EpsTunnelRemover
 from .epstunnels import FinalEpsTunnelRemover
+from .canonicalisation import DropoutRemover
 import torch.fx as fx
 from quantlib.editing.editing.editors import ComposedEditor
 from quantlib.editing.editing.editors.base.editor import Editor

--- a/editing/editing/fake2true/__init__.py
+++ b/editing/editing/fake2true/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from . import annotation
 from . import epstunnels
 from . import integerisation

--- a/editing/editing/fake2true/__init__.py
+++ b/editing/editing/fake2true/__init__.py
@@ -46,6 +46,7 @@ from .epstunnels import EpsTunnelInserter
 from .integerisation import F2TIntegeriser
 from .epstunnels import EpsTunnelConstructSimplifier
 from .epstunnels import EpsTunnelRemover
+from .epstunnels import FinalEpsTunnelRemover
 import torch.fx as fx
 from quantlib.editing.editing.editors import ComposedEditor
 from quantlib.editing.editing.editors.base.editor import Editor

--- a/editing/editing/fake2true/annotation/__init__.py
+++ b/editing/editing/fake2true/annotation/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .shapepropagator import *
 from .epspropagator import *
 

--- a/editing/editing/fake2true/annotation/epspropagator/__init__.py
+++ b/editing/editing/fake2true/annotation/epspropagator/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .inputscales import InputScales
 from .annotator import EpsPropagator
 

--- a/editing/editing/fake2true/annotation/epspropagator/annotator.py
+++ b/editing/editing/fake2true/annotation/epspropagator/annotator.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import copy
 import torch
 import torch.fx as fx

--- a/editing/editing/fake2true/annotation/epspropagator/inputscales.py
+++ b/editing/editing/fake2true/annotation/epspropagator/inputscales.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from collections import OrderedDict
 from enum import Enum
 import torch

--- a/editing/editing/fake2true/annotation/epspropagator/propagationrules/__init__.py
+++ b/editing/editing/fake2true/annotation/epspropagator/propagationrules/__init__.py
@@ -1,2 +1,21 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .rule import UNDEFINED_EPS
 from .rule import _module_2_epspec, _method_2_epspec, _function_2_epspec, is_eps_annotated

--- a/editing/editing/fake2true/annotation/epspropagator/propagationrules/rule.py
+++ b/editing/editing/fake2true/annotation/epspropagator/propagationrules/rule.py
@@ -164,6 +164,7 @@ EpsPropagationSpec = collections.namedtuple('EpsPropagationSpec', ['function', '
 _module_2_epspec = {
     nn.ReLU:      EpsPropagationSpec(function=propagate_under_tolerance, args=[], kwargs={'tolerance': ZERO_TOLERANCE}),  # TODO: I assume that zero is a valid quantisation level; e.g., the quantum of {-0.33, 0.17, 0.67} is 0.5, but the quantum of ReLU({-0.33, 0.17, 0.67}) = {0.0, 0.17, 0.67} is 0.01.
     nn.Identity:  EpsPropagationSpec(function=propagate_under_tolerance, args=[], kwargs={'tolerance': ZERO_TOLERANCE}),
+    nn.Flatten:   EpsPropagationSpec(function=propagate_under_tolerance, args=[], kwargs={'tolerance': ZERO_TOLERANCE}),
     nn.MaxPool1d: EpsPropagationSpec(function=propagate_under_tolerance, args=[], kwargs={'tolerance': ZERO_TOLERANCE}),
     nn.MaxPool2d: EpsPropagationSpec(function=propagate_under_tolerance, args=[], kwargs={'tolerance': ZERO_TOLERANCE}),
     nn.MaxPool3d: EpsPropagationSpec(function=propagate_under_tolerance, args=[], kwargs={'tolerance': ZERO_TOLERANCE}),

--- a/editing/editing/fake2true/annotation/epspropagator/propagationrules/rule.py
+++ b/editing/editing/fake2true/annotation/epspropagator/propagationrules/rule.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import collections
 import torch
 import torch.nn as nn

--- a/editing/editing/fake2true/annotation/inputdescription.py
+++ b/editing/editing/fake2true/annotation/inputdescription.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from collections import OrderedDict
 from enum import Enum
 import torch

--- a/editing/editing/fake2true/annotation/shapepropagator/__init__.py
+++ b/editing/editing/fake2true/annotation/shapepropagator/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .shapeanddtype import ShapeAndDType, InputShapesAndDTypes
 from .annotator import ShapePropagator
 

--- a/editing/editing/fake2true/annotation/shapepropagator/annotator.py
+++ b/editing/editing/fake2true/annotation/shapepropagator/annotator.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch
 import torch.fx as fx
 from torch.fx.passes.shape_prop import ShapeProp

--- a/editing/editing/fake2true/annotation/shapepropagator/shapeanddtype.py
+++ b/editing/editing/fake2true/annotation/shapepropagator/shapeanddtype.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from collections import OrderedDict
 from enum import Enum
 import torch

--- a/editing/editing/fake2true/canonicalisation/__init__.py
+++ b/editing/editing/fake2true/canonicalisation/__init__.py
@@ -1,1 +1,20 @@
+# 
+# Author(s):
+# Francesco Conti <f.conti@unibo.it>
+# 
+# Copyright (c) 2020-2023 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .dropoutremover import *

--- a/editing/editing/fake2true/canonicalisation/__init__.py
+++ b/editing/editing/fake2true/canonicalisation/__init__.py
@@ -1,0 +1,1 @@
+from .dropoutremover import *

--- a/editing/editing/fake2true/canonicalisation/dropoutremover/__init__.py
+++ b/editing/editing/fake2true/canonicalisation/dropoutremover/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Francesco Conti <f.conti@unibo.it>
+# 
+# Copyright (c) 2020-2023 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from torch import fx
 import torch.nn as nn
 import quantlib.editing.graphs as qg

--- a/editing/editing/fake2true/canonicalisation/dropoutremover/__init__.py
+++ b/editing/editing/fake2true/canonicalisation/dropoutremover/__init__.py
@@ -1,0 +1,61 @@
+from torch import fx
+import torch.nn as nn
+import quantlib.editing.graphs as qg
+import quantlib.editing.editing as qe
+
+class BadDropoutTemplate(nn.Module):
+    
+    # opcode       name     target    args        kwargs
+    # -----------  -------  --------  ----------  --------
+    # placeholder  x        x         ()          {}
+    # call_module  dropout  dropout   (x,)        {}
+    # output       output   output    (dropout,)  {}
+
+    def __init__(self):
+        super(BadDropoutTemplate, self).__init__()
+        self.dropout = nn.Dropout()
+    
+    def forward(self, x):
+        return self.dropout(x)
+
+class DropoutRemoverApplier(qe.editors.nnmodules.NNModuleApplier):
+
+    def __init__(self, pattern: qe.editors.nnmodules.GenericNNModulePattern):
+        super(DropoutRemoverApplier, self).__init__(pattern)
+
+    def _apply(self, g: fx.GraphModule, ap: qe.editors.nnmodules.NodesMap, id_: str) -> fx.GraphModule:
+
+        name_to_match_node = self.pattern.name_to_match_node(nodes_map=ap)
+        node_dropout = name_to_match_node['dropout']
+
+        # create the new module
+        new_target = id_
+        new_module = nn.Identity()
+
+        # add the new module to graph
+        g.add_submodule(new_target, new_module)
+        node_input  = next(iter(node_dropout.all_input_nodes))
+        node_output = node_dropout.next
+        node_output.replace_input_with(node_dropout, node_input)
+
+        # ...and delete the old operation
+        g.delete_submodule(node_dropout.target)
+        g.graph.erase_node(node_dropout)
+
+        return g
+
+class DropoutRemover(qe.editors.nnmodules.NNModuleRewriter):
+
+    def __init__(self):
+        # create pattern
+        dropout_withcheckers = qe.editors.nnmodules.NNModuleWithCheckers(BadDropoutTemplate(), {})
+        dropout_pattern = qe.editors.nnmodules.GenericNNModulePattern(qg.fx.quantlib_symbolic_trace, dropout_withcheckers)
+        # create matcher and applier
+        finder = qe.editors.nnmodules.GenericGraphMatcher(dropout_pattern)
+        applier = DropoutRemoverApplier(dropout_pattern)
+        # link pattern, matcher, and applier into the rewriter
+        super(DropoutRemover, self).__init__('DropoutRemover', dropout_pattern, finder, applier)
+
+__all__ = [
+    'DropoutRemover',
+]

--- a/editing/editing/fake2true/epstunnels/__init__.py
+++ b/editing/editing/fake2true/epstunnels/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .inserter import *
 from .simplifier import *
 from .remover import *

--- a/editing/editing/fake2true/epstunnels/__init__.py
+++ b/editing/editing/fake2true/epstunnels/__init__.py
@@ -1,3 +1,4 @@
 from .inserter import *
 from .simplifier import *
 from .remover import *
+from .finalremover import *

--- a/editing/editing/fake2true/epstunnels/finalremover/__init__.py
+++ b/editing/editing/fake2true/epstunnels/finalremover/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Francesco Conti <f.conti@unibo.it>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .rewriter import FinalEpsTunnelRemover
 
 __all__ = [

--- a/editing/editing/fake2true/epstunnels/finalremover/__init__.py
+++ b/editing/editing/fake2true/epstunnels/finalremover/__init__.py
@@ -1,0 +1,5 @@
+from .rewriter import FinalEpsTunnelRemover
+
+__all__ = [
+    'FinalEpsTunnelRemover',
+]

--- a/editing/editing/fake2true/epstunnels/finalremover/applier.py
+++ b/editing/editing/fake2true/epstunnels/finalremover/applier.py
@@ -21,7 +21,7 @@ class FinalEpsTunnelRemoverApplier(Applier):
             s.replace_input_with(node, p)
         torch.set_printoptions(precision=16)
         print("[FinalEpsTunnelRemover] %s: removing EpsTunnel with scaling factor %s" % (s, g.get_submodule(node.target).eps_out/g.get_submodule(node.target).eps_in))
-        print("[FinalEpsTunnelRemover] %s: outputs will need to be scaled *externally* to maintain program semantics.")
+        print("[FinalEpsTunnelRemover] %s: outputs will need to be scaled *externally* to maintain program semantics." % (s,))
         torch.set_printoptions()
 
         g.delete_submodule(node.target)

--- a/editing/editing/fake2true/epstunnels/finalremover/applier.py
+++ b/editing/editing/fake2true/epstunnels/finalremover/applier.py
@@ -1,0 +1,30 @@
+import itertools
+import torch.fx as fx
+import torch
+
+from ..remover.applicationpoint import EpsTunnelNode
+from quantlib.editing.editing.editors import Applier
+
+
+class FinalEpsTunnelRemoverApplier(Applier):
+
+    def _apply(self, g: fx.GraphModule, ap: EpsTunnelNode, id_: str) -> fx.GraphModule:
+
+        node = ap.node
+
+        # the `fx.Node` is functionally equivalent to the identity, so we connect its (unique) input to all the outputs
+        predecessors = {p for p in node.all_input_nodes}  # upstream
+        assert len(predecessors) == 1
+        successors = {s for s in node.users}  # downstream
+        assert len(successors) == 1
+        for p, s in itertools.product(predecessors, successors):
+            s.replace_input_with(node, p)
+        torch.set_printoptions(precision=16)
+        print("[FinalEpsTunnelRemover] %s: removing EpsTunnel with scaling factor %s" % (s, g.get_submodule(node.target).eps_out/g.get_submodule(node.target).eps_in))
+        print("[FinalEpsTunnelRemover] %s: outputs will need to be scaled *externally* to maintain program semantics.")
+        torch.set_printoptions()
+
+        g.delete_submodule(node.target)
+        g.graph.erase_node(node)
+
+        return g

--- a/editing/editing/fake2true/epstunnels/finalremover/applier.py
+++ b/editing/editing/fake2true/epstunnels/finalremover/applier.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Francesco Conti <f.conti@unibo.it>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import itertools
 import torch.fx as fx
 import torch

--- a/editing/editing/fake2true/epstunnels/finalremover/finder.py
+++ b/editing/editing/fake2true/epstunnels/finalremover/finder.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Francesco Conti <f.conti@unibo.it>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch
 import torch.fx as fx
 from typing import List

--- a/editing/editing/fake2true/epstunnels/finalremover/finder.py
+++ b/editing/editing/fake2true/epstunnels/finalremover/finder.py
@@ -1,0 +1,26 @@
+import torch
+import torch.fx as fx
+from typing import List
+
+from ..remover.applicationpoint import EpsTunnelNode
+from quantlib.editing.editing.editors import Finder
+from quantlib.editing.graphs.fx import FXOpcodeClasses
+from quantlib.editing.graphs.nn import EpsTunnel
+
+
+class FinalEpsTunnelRemoverFinder(Finder):
+
+    def find(self, g: fx.GraphModule) -> List[EpsTunnelNode]:
+
+        # find `EpsTunnel` `fx.Node`s
+        module_nodes = filter(lambda n: (n.op in FXOpcodeClasses.CALL_MODULE.value), g.graph.nodes)
+
+        # select only output nodes
+        epstunnels = list(filter(lambda n: isinstance(g.get_submodule(target=n.target), EpsTunnel), module_nodes))  # since we consume the `filter` generator twice in the next lines, we must ensure that it does not get empty after the first consumption
+        singleusertunnels = list(filter(lambda n: len(n.users) == 1, epstunnels))
+        outputtunnels = list(filter(lambda n: list(n.users.keys())[0].op == "output", singleusertunnels))
+
+        return [EpsTunnelNode(n) for n in list(outputtunnels)]
+
+    def check_aps_commutativity(self, aps: List[EpsTunnelNode]) -> bool:
+        return len(aps) == len(set(map(lambda ap: ap.node, aps)))

--- a/editing/editing/fake2true/epstunnels/finalremover/rewriter.py
+++ b/editing/editing/fake2true/epstunnels/finalremover/rewriter.py
@@ -1,0 +1,13 @@
+from .finder import FinalEpsTunnelRemoverFinder
+from .applier import FinalEpsTunnelRemoverApplier
+from quantlib.editing.editing.editors import Rewriter
+from quantlib.editing.graphs.fx import quantlib_symbolic_trace
+
+# removes the output node eps-tunnel
+class FinalEpsTunnelRemover(Rewriter):
+
+    def __init__(self):
+        super(FinalEpsTunnelRemover, self).__init__('FinalEpsTunnelRemover',
+                                               quantlib_symbolic_trace,
+                                               FinalEpsTunnelRemoverFinder(),
+                                               FinalEpsTunnelRemoverApplier())

--- a/editing/editing/fake2true/epstunnels/finalremover/rewriter.py
+++ b/editing/editing/fake2true/epstunnels/finalremover/rewriter.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Francesco Conti <f.conti@unibo.it>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .finder import FinalEpsTunnelRemoverFinder
 from .applier import FinalEpsTunnelRemoverApplier
 from quantlib.editing.editing.editors import Rewriter

--- a/editing/editing/fake2true/epstunnels/inserter/__init__.py
+++ b/editing/editing/fake2true/epstunnels/inserter/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .rewriter import EpsTunnelInserter
 
 __all__ = [

--- a/editing/editing/fake2true/epstunnels/inserter/applicationpoint.py
+++ b/editing/editing/fake2true/epstunnels/inserter/applicationpoint.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 """The object passed between ``EpsTunnelInserterFinder``s and
 ``EpsTunnelInserterApplier``s."""
 

--- a/editing/editing/fake2true/epstunnels/inserter/applier.py
+++ b/editing/editing/fake2true/epstunnels/inserter/applier.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch.fx as fx
 
 from .applicationpoint import EpsTunnelNode

--- a/editing/editing/fake2true/epstunnels/inserter/applier.py
+++ b/editing/editing/fake2true/epstunnels/inserter/applier.py
@@ -36,7 +36,7 @@ class EpsTunnelInserterApplier(Applier):
             local_counter: int = 0
             for u in downstream_nodes:
 
-                new_target_copy = id_ + f'[{str(local_counter)}]'
+                new_target_copy = id_ + f'_{str(local_counter)}_'
                 new_module_copy = EpsTunnel(node.meta['eps'])
 
                 g.add_submodule(new_target_copy, new_module_copy)

--- a/editing/editing/fake2true/epstunnels/inserter/finder.py
+++ b/editing/editing/fake2true/epstunnels/inserter/finder.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch.fx as fx
 from typing import List
 

--- a/editing/editing/fake2true/epstunnels/inserter/rewriter.py
+++ b/editing/editing/fake2true/epstunnels/inserter/rewriter.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .finder import EpsTunnelInserterFinder
 from .applier import EpsTunnelInserterApplier
 from quantlib.editing.editing.editors import Rewriter

--- a/editing/editing/fake2true/epstunnels/remover/__init__.py
+++ b/editing/editing/fake2true/epstunnels/remover/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .rewriter import EpsTunnelRemover
 
 __all__ = [

--- a/editing/editing/fake2true/epstunnels/remover/applicationpoint.py
+++ b/editing/editing/fake2true/epstunnels/remover/applicationpoint.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 """The object passed between ``EpsTunnelInserterFinder``s and
 ``EpsTunnelInserterApplier``s."""
 

--- a/editing/editing/fake2true/epstunnels/remover/applier.py
+++ b/editing/editing/fake2true/epstunnels/remover/applier.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import itertools
 import torch.fx as fx
 

--- a/editing/editing/fake2true/epstunnels/remover/finder.py
+++ b/editing/editing/fake2true/epstunnels/remover/finder.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch
 import torch.fx as fx
 from typing import List

--- a/editing/editing/fake2true/epstunnels/remover/rewriter.py
+++ b/editing/editing/fake2true/epstunnels/remover/rewriter.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .finder import EpsTunnelRemoverFinder
 from .applier import EpsTunnelRemoverApplier
 from quantlib.editing.editing.editors import Rewriter

--- a/editing/editing/fake2true/epstunnels/simplifier/__init__.py
+++ b/editing/editing/fake2true/epstunnels/simplifier/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .rewriter import EpsTunnelConstructSimplifier
 
 __all__ = [

--- a/editing/editing/fake2true/epstunnels/simplifier/applicationpoint.py
+++ b/editing/editing/fake2true/epstunnels/simplifier/applicationpoint.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch.fx as fx
 from typing import Set, NamedTuple
 

--- a/editing/editing/fake2true/epstunnels/simplifier/applier.py
+++ b/editing/editing/fake2true/epstunnels/simplifier/applier.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch
 import torch.fx as fx
 

--- a/editing/editing/fake2true/epstunnels/simplifier/finder/__init__.py
+++ b/editing/editing/fake2true/epstunnels/simplifier/finder/__init__.py
@@ -1,1 +1,20 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .finder import EpsTunnelConstructFinder

--- a/editing/editing/fake2true/epstunnels/simplifier/finder/algorithm.py
+++ b/editing/editing/fake2true/epstunnels/simplifier/finder/algorithm.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch
 import torch.fx as fx
 from typing import Set, List

--- a/editing/editing/fake2true/epstunnels/simplifier/finder/finder.py
+++ b/editing/editing/fake2true/epstunnels/simplifier/finder/finder.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch.fx as fx
 from typing import List
 

--- a/editing/editing/fake2true/epstunnels/simplifier/finder/whitelists.py
+++ b/editing/editing/fake2true/epstunnels/simplifier/finder/whitelists.py
@@ -36,6 +36,8 @@ def verify_avgpoolnd(n: fx.Node) -> bool:
 
 
 whitelist_call_module = OrderedDict([
+    # flatten
+    (nn.Flatten, []),
     # max pooling
     (nn.MaxPool1d, []),
     (nn.MaxPool2d, []),

--- a/editing/editing/fake2true/epstunnels/simplifier/finder/whitelists.py
+++ b/editing/editing/fake2true/epstunnels/simplifier/finder/whitelists.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from collections import OrderedDict
 import torch.nn as nn
 import torch.fx as fx

--- a/editing/editing/fake2true/epstunnels/simplifier/rewriter.py
+++ b/editing/editing/fake2true/epstunnels/simplifier/rewriter.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .finder import EpsTunnelConstructFinder
 from .applier import EpsTunnelConstructApplier
 from quantlib.editing.editing.editors import Rewriter

--- a/editing/editing/fake2true/integerisation/__init__.py
+++ b/editing/editing/fake2true/integerisation/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .linearopintegeriser import *
 from .requantiser import *
 from .addrequantisationmerger import *

--- a/editing/editing/fake2true/integerisation/__init__.py
+++ b/editing/editing/fake2true/integerisation/__init__.py
@@ -1,6 +1,6 @@
 from .linearopintegeriser import *
 from .requantiser import *
-
+from .addrequantisationmerger import *
 
 from quantlib.editing.editing.editors import ComposedEditor
 

--- a/editing/editing/fake2true/integerisation/addrequantisationmerger/__init__.py
+++ b/editing/editing/fake2true/integerisation/addrequantisationmerger/__init__.py
@@ -1,0 +1,94 @@
+from torch import fx
+import torch.nn as nn
+import quantlib.editing.graphs as qg
+import quantlib.editing.editing as qe
+import torch
+
+from quantlib.editing.graphs.nn import Requantisation
+
+class AddRequantisationPattern(nn.Module):
+
+    def __init__(self):
+        super(AddRequantisationPattern, self).__init__()
+        self.requant1 = Requantisation(mul=torch.ones(1), add=torch.zeros(1), zero=torch.zeros(1), n_levels=torch.ones(1))
+        self.requant2 = Requantisation(mul=torch.ones(1), add=torch.zeros(1), zero=torch.zeros(1), n_levels=torch.ones(1))
+        self.requanto = Requantisation(mul=torch.ones(1), add=torch.zeros(1), zero=torch.zeros(1), n_levels=torch.ones(1))
+    
+    def forward(self, x, y):
+        x = self.requant1(x)
+        x = self.requant2(x)
+        x = x + y
+        x = self.requanto(x)
+        return x
+
+class AddRequantisationMergerApplier(qe.editors.nnmodules.NNModuleApplier):
+
+    def __init__(self, pattern: qe.editors.nnmodules.GenericNNModulePattern):
+        super(AddRequantisationMergerApplier, self).__init__(pattern)
+
+    def _apply(self, g: fx.GraphModule, ap: qe.editors.nnmodules.NodesMap, id_: str) -> fx.GraphModule:
+
+        name_to_match_node = self.pattern.name_to_match_node(nodes_map=ap)
+        node_requant1 = name_to_match_node['requant1']
+        node_requant2 = name_to_match_node['requant2']
+
+        try:
+            name_to_match_module = self.pattern.name_to_match_module(nodes_map=ap, data_gm=g)
+        except RuntimeError:
+            # this means this particular application point has already been managed
+            return g
+        module_requant1 = name_to_match_module['requant1']
+        module_requant2 = name_to_match_module['requant2']
+
+        # change zero, n_levels of first requant module
+        clip_lo = max(module_requant1.zero, module_requant2.zero)
+        clip_hi = min(module_requant1.zero + module_requant1.n_levels, module_requant2.zero + module_requant2.n_levels)
+        n_levels = clip_hi - clip_lo
+        zero = clip_lo
+        print(module_requant1.zero, module_requant2.zero, zero)
+        print(module_requant1.n_levels, module_requant2.n_levels, n_levels)
+
+        # change mul, add, div of first requant module
+        mul = torch.floor((module_requant1.mul * module_requant2.mul) / module_requant1.div)
+        add = torch.floor((module_requant1.add * module_requant2.mul + module_requant1.div * module_requant2.add) / module_requant1.div)
+        div = module_requant2.div
+        print(module_requant1.mul, module_requant2.mul, mul)
+        print(module_requant1.add, module_requant2.add, add)
+        print(module_requant1.div, module_requant2.div, div)
+
+        # create module
+        new_module = Requantisation(mul=mul, add=add, zero=zero, n_levels=n_levels, D=div)
+
+        # add the new module to graph
+        new_target = id_
+        g.add_submodule(new_target, new_module)
+        new_input = next(iter(node_requant1.all_input_nodes))
+        with g.graph.inserting_after(new_input):
+            new_node = g.graph.call_module(new_target, args=(new_input,))
+        node_requant2.replace_all_uses_with(new_node)
+        node_requant1.replace_all_uses_with(new_node)
+
+        # ...and delete the old operation
+        g.delete_submodule(node_requant2.target)
+        g.graph.erase_node(node_requant2)
+        g.delete_submodule(node_requant1.target)
+        g.graph.erase_node(node_requant1)
+        g.graph.lint()
+
+        return g
+
+class AddRequantisationMerger(qe.editors.nnmodules.NNModuleRewriter):
+
+    def __init__(self):
+        # create pattern
+        requantisation_withcheckers = qe.editors.nnmodules.NNModuleWithCheckers(AddRequantisationPattern(), {})
+        requantisation_pattern = qe.editors.nnmodules.GenericNNModulePattern(qg.fx.quantlib_symbolic_trace, requantisation_withcheckers)
+        # create matcher and applier
+        finder = qe.editors.nnmodules.GenericGraphMatcher(requantisation_pattern)
+        applier = AddRequantisationMergerApplier(requantisation_pattern)
+        # link pattern, matcher, and applier into the rewriter
+        super(AddRequantisationMerger, self).__init__('AddRequantisationMerger', requantisation_pattern, finder, applier)
+
+__all__ = [
+    'AddRequantisationMerger',
+]

--- a/editing/editing/fake2true/integerisation/addrequantisationmerger/__init__.py
+++ b/editing/editing/fake2true/integerisation/addrequantisationmerger/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Francesco Conti <f.conti@unibo.it>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from torch import fx
 import torch.nn as nn
 import quantlib.editing.graphs as qg

--- a/editing/editing/fake2true/integerisation/linearopintegeriser/__init__.py
+++ b/editing/editing/fake2true/integerisation/linearopintegeriser/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from collections import OrderedDict
 import torch
 import torch.nn as nn

--- a/editing/editing/fake2true/integerisation/linearopintegeriser/applier.py
+++ b/editing/editing/fake2true/integerisation/linearopintegeriser/applier.py
@@ -27,7 +27,10 @@ class LinearOpIntegeriserApplier(NNModuleApplier):
             class_ = nn.Linear
             new_module = class_(in_features=qlinear.in_features,
                                 out_features=qlinear.out_features,
-                                bias=qlinear.bias)
+                                bias=True)
+            if not qlinear.bias:
+                with torch.no_grad():
+                    new_module.bias[:] = 0
 
         elif isinstance(qlinear, (nn.Conv1d, nn.Conv2d, nn.Conv3d,)):
             if isinstance(qlinear, nn.Conv1d):

--- a/editing/editing/fake2true/integerisation/linearopintegeriser/applier.py
+++ b/editing/editing/fake2true/integerisation/linearopintegeriser/applier.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch
 import torch.nn as nn
 import torch.fx as fx

--- a/editing/editing/fake2true/integerisation/linearopintegeriser/finder.py
+++ b/editing/editing/fake2true/integerisation/linearopintegeriser/finder.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from quantlib.editing.editing.editors.nnmodules import NNSequentialPattern, PathGraphMatcher
 
 

--- a/editing/editing/fake2true/integerisation/requantiser/__init__.py
+++ b/editing/editing/fake2true/integerisation/requantiser/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from collections import OrderedDict
 import torch
 import torch.nn as nn

--- a/editing/editing/fake2true/integerisation/requantiser/applier.py
+++ b/editing/editing/fake2true/integerisation/requantiser/applier.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch
 import torch.nn as nn
 import torch.fx as fx

--- a/editing/editing/fake2true/integerisation/requantiser/finder.py
+++ b/editing/editing/fake2true/integerisation/requantiser/finder.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from quantlib.editing.editing.editors.nnmodules import NNSequentialPattern, PathGraphMatcher
 
 

--- a/editing/editing/fake2true/integerisation/test_linearopintegeriser.py
+++ b/editing/editing/fake2true/integerisation/test_linearopintegeriser.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import unittest
 from collections import OrderedDict
 import torch

--- a/editing/editing/float2fake/__init__.py
+++ b/editing/editing/float2fake/__init__.py
@@ -2,6 +2,7 @@ from typing import Callable
 import quantlib.algorithms as qa
 from quantlib.editing.editing.float2fake.quantisation.activationrounder import ActivationRounder
 from quantlib.editing.editing.float2fake.quantisation.weightrounder import WeightRounder
+from quantlib.editing.editing.float2fake.quantisation.addcalibrator import AddCalibrator
 from . import canonicalisation
 from . import quantisation
 from contextlib import contextmanager
@@ -140,22 +141,19 @@ class F2F8bitPACTRounder(ComposedEditor):
     This rounder should be used after the network has been quantized (e.g.,
     with `F2F8bitPACTRoundingConverter`) and calibrated using 
     ```
-    for m in net.modules():
-        if isinstance(m, tuple(qa.qalgorithms.qatalgorithms.pact.NNMODULE_TO_PACTMODULE.values())):
-            m.start_observing()
-    validate(net)
-    for m in net.modules():
-        if isinstance(m, tuple(qa.qalgorithms.qatalgorithms.pact.NNMODULE_TO_PACTMODULE.values())):
-            m.stop_observing()
+    with qe.float2fake.calibration(net):
+        validate(net)
     ```
-    applied *after* the quantization hyperparameters have been calibrated).
+    Besides rounding, it also harmonizes add nodes.
+    FIXME: maybe change the name to Calibrator or similar.
 
     """
     def __init__(self):
 
         super(F2F8bitPACTRounder, self).__init__([
             WeightRounder(),
-            ActivationRounder()
+            ActivationRounder(),
+            AddCalibrator()
         ])
 
 @contextmanager

--- a/editing/editing/float2fake/__init__.py
+++ b/editing/editing/float2fake/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from typing import Callable
 import quantlib.algorithms as qa
 from quantlib.editing.editing.float2fake.quantisation.activationrounder import ActivationRounder

--- a/editing/editing/float2fake/canonicalisation/__init__.py
+++ b/editing/editing/float2fake/canonicalisation/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .activationmodulariser import *
 from .linearopbnbiasfolder import *
 from .flattencanonicaliser import *

--- a/editing/editing/float2fake/canonicalisation/__init__.py
+++ b/editing/editing/float2fake/canonicalisation/__init__.py
@@ -1,5 +1,6 @@
 from .activationmodulariser import *
 from .linearopbnbiasfolder import *
+from .flattencanonicaliser import *
 
 #
 # In the following, we define a high-level `Editor` (i.e., a `ComposedEditor`)
@@ -35,4 +36,5 @@ class F2FCanonicaliser(ComposedEditor):
             ActivationModulariser(),
             QuantLibRetracer(),
             LinearOpBNBiasFolder(),
+            FlattenCanonicaliser()
         ])

--- a/editing/editing/float2fake/canonicalisation/activationmodulariser/__init__.py
+++ b/editing/editing/float2fake/canonicalisation/activationmodulariser/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from collections import OrderedDict
 import torch
 import torch.nn as nn

--- a/editing/editing/float2fake/canonicalisation/activationmodulariser/activationspecification.py
+++ b/editing/editing/float2fake/canonicalisation/activationmodulariser/activationspecification.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 """The object guiding ``ActivationFinder``s when filtering ``fx.Node``s, and
 ``ActivationReplacer``s when building modular activations.
 """

--- a/editing/editing/float2fake/canonicalisation/activationmodulariser/applicationpoint.py
+++ b/editing/editing/float2fake/canonicalisation/activationmodulariser/applicationpoint.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 """The object passed between ``ActivationFinder``s and ``ActivationReplacer``s."""
 
 import torch.fx as fx

--- a/editing/editing/float2fake/canonicalisation/activationmodulariser/applier.py
+++ b/editing/editing/float2fake/canonicalisation/activationmodulariser/applier.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch.nn as nn
 import torch.fx as fx
 from typing import Tuple, Dict

--- a/editing/editing/float2fake/canonicalisation/activationmodulariser/finder.py
+++ b/editing/editing/float2fake/canonicalisation/activationmodulariser/finder.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch.fx as fx
 from typing import List
 

--- a/editing/editing/float2fake/canonicalisation/flattencanonicaliser/__init__.py
+++ b/editing/editing/float2fake/canonicalisation/flattencanonicaliser/__init__.py
@@ -1,0 +1,74 @@
+import torch
+from torch import nn, fx
+from quantlib.editing.editing.editors.base.editor import Editor
+
+class BadFlatten1Template(nn.Module):
+
+    # opcode       name    target    args           kwargs
+    # -----------  ------  --------  -------------  --------
+    # placeholder  x       x         ()             {}
+    # call_method  size    size      (x, 0)         {}
+    # call_method  view    view      (x, size, -1)  {}
+    # output       output  output    (view,)        {}
+
+    def __init__(self):
+        super(BadFlatten1Template, self).__init__()
+    
+    def forward(self, x):
+        x = x.view(x.size(0), -1)
+        return x
+
+class BadFlatten2Template(nn.Module):
+
+    # opcode       name     target    args        kwargs
+    # -----------  -------  --------  ----------  --------
+    # placeholder  x        x         ()          {}
+    # call_method  flatten  flatten   (x, 1, -1)  {}
+    # output       output   output    (flatten,)  {}
+
+    def __init__(self):
+        super(BadFlatten2Template, self).__init__()
+    
+    def forward(self, x):
+        x = x.flatten(1, -1)
+        return x
+
+class GoodFlattenTemplate(nn.Module):
+
+    # opcode       name     target    args        kwargs
+    # -----------  -------  --------  ----------  --------
+    # placeholder  x        x         ()          {}
+    # call_module  flatten  flatten   (x,)        {}
+    # output       output   output    (flatten,)  {}
+
+    def __init__(self):
+        super(GoodFlattenTemplate, self).__init__()
+        self.flatten = torch.nn.Flatten()
+    
+    def forward(self, x):
+        x = self.flatten(x)
+        return x
+
+# TODO: this implementation works, but it uses plain torch.fx instead of
+#       the more sophisticated functionality of Rewriters.
+#       At this time, I did not manage to get the Rewriters to work with
+#       the Flatten patterns, which do not employ module nodes but 
+#       method nodes.
+class FlattenCanonicaliser(Editor):
+
+    """This editor canonicalises the representation of Flatten nodes.
+    """
+    def __init__(self):
+        super(FlattenCanonicaliser, self).__init__()
+
+    def apply(self, g: fx.GraphModule, *args, **kwargs) -> fx.GraphModule:
+        mbad1 = BadFlatten1Template()
+        mbad2 = BadFlatten2Template()
+        mgood = GoodFlattenTemplate()
+        gbad1 = fx.symbolic_trace(mbad1)
+        gbad2 = fx.symbolic_trace(mbad2)
+        ggood = fx.symbolic_trace(mgood)
+        fx.replace_pattern(g, gbad1, ggood)
+        fx.replace_pattern(g, gbad2, ggood)
+        return g
+        

--- a/editing/editing/float2fake/canonicalisation/flattencanonicaliser/__init__.py
+++ b/editing/editing/float2fake/canonicalisation/flattencanonicaliser/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Francesco Conti <f.conti@unibo.it>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch
 from torch import nn, fx
 from quantlib.editing.editing.editors.base.editor import Editor

--- a/editing/editing/float2fake/canonicalisation/linearopbnbiasfolder/__init__.py
+++ b/editing/editing/float2fake/canonicalisation/linearopbnbiasfolder/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from collections import OrderedDict
 import torch.nn as nn
 

--- a/editing/editing/float2fake/canonicalisation/linearopbnbiasfolder/applier.py
+++ b/editing/editing/float2fake/canonicalisation/linearopbnbiasfolder/applier.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch.fx as fx
 
 from quantlib.editing.editing.editors.nnmodules import NodesMap

--- a/editing/editing/float2fake/canonicalisation/test_linearopbnbiasfolder.py
+++ b/editing/editing/float2fake/canonicalisation/test_linearopbnbiasfolder.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import unittest
 from collections import OrderedDict
 import torch.nn as nn

--- a/editing/editing/float2fake/quantisation/__init__.py
+++ b/editing/editing/float2fake/quantisation/__init__.py
@@ -4,6 +4,7 @@ from .addtreeharmoniser import *
 from .quantiserinterposer import *
 from .activationrounder import *
 from .weightrounder import *
+from .addcalibrator import *
 
 #
 # In the following, we define a high-level `Editor` (i.e., a `ComposedEditor`)

--- a/editing/editing/float2fake/quantisation/activationrounder/__init__.py
+++ b/editing/editing/float2fake/quantisation/activationrounder/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Francesco Conti <f.conti@unibo.it>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from collections import OrderedDict
 from quantlib.algorithms.qalgorithms.qatalgorithms.pact.qactivations import PACTReLU, PACTReLU6, PACTLeakyReLU
 import torch.nn as nn

--- a/editing/editing/float2fake/quantisation/activationrounder/applier.py
+++ b/editing/editing/float2fake/quantisation/activationrounder/applier.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Francesco Conti <f.conti@unibo.it>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from quantlib.algorithms.qbase.qhparams.qhparams import get_zero_scale
 import torch
 import torch.fx as fx

--- a/editing/editing/float2fake/quantisation/addcalibrator/__init__.py
+++ b/editing/editing/float2fake/quantisation/addcalibrator/__init__.py
@@ -1,0 +1,23 @@
+import quantlib.editing.editing as qe
+import quantlib.editing.graphs as qg
+from quantlib.editing.editing.editors import Annotator
+from quantlib.editing.graphs.fx import quantlib_symbolic_trace
+import torch.nn as nn
+import torch.fx as fx
+
+# harmonises the HarmonisedAdd post-calibration
+class AddCalibrator(Annotator):
+
+    def __init__(self):
+        super(AddCalibrator, self).__init__('AddCalibrator', quantlib_symbolic_trace)
+
+    def apply(self,
+              g: fx.GraphModule):
+        for _, m in g.named_modules():
+            if m.__class__.__name__ == "HarmonisedAdd":
+                m.harmonise()
+        return g
+
+__all__ = [
+    'AddCalibrator',
+]

--- a/editing/editing/float2fake/quantisation/addcalibrator/__init__.py
+++ b/editing/editing/float2fake/quantisation/addcalibrator/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import quantlib.editing.editing as qe
 import quantlib.editing.graphs as qg
 from quantlib.editing.editing.editors import Annotator

--- a/editing/editing/float2fake/quantisation/addtreeharmoniser/__init__.py
+++ b/editing/editing/float2fake/quantisation/addtreeharmoniser/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .tracing import QuantLibHarmonisedAddTracer, quantlib_harmonisedadd_symbolic_trace
 from .retracer import QuantLibHarmonisedAddRetracer
 from .rewriter import AddTreeHarmoniser

--- a/editing/editing/float2fake/quantisation/addtreeharmoniser/applier.py
+++ b/editing/editing/float2fake/quantisation/addtreeharmoniser/applier.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import copy
 import torch.fx as fx
 

--- a/editing/editing/float2fake/quantisation/addtreeharmoniser/finder.py
+++ b/editing/editing/float2fake/quantisation/addtreeharmoniser/finder.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import operator
 import torch
 

--- a/editing/editing/float2fake/quantisation/addtreeharmoniser/retracer.py
+++ b/editing/editing/float2fake/quantisation/addtreeharmoniser/retracer.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch.fx as fx
 
 from quantlib.editing.editing.editors import Annotator

--- a/editing/editing/float2fake/quantisation/addtreeharmoniser/rewriter.py
+++ b/editing/editing/float2fake/quantisation/addtreeharmoniser/rewriter.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .tracing import quantlib_harmonisedadd_symbolic_trace
 from .finder import AddTreeFinder
 from .applier import AddTreeApplier

--- a/editing/editing/float2fake/quantisation/addtreeharmoniser/tracing.py
+++ b/editing/editing/float2fake/quantisation/addtreeharmoniser/tracing.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from functools import partial
 
 from quantlib.editing.graphs.fx import QuantLibTracer, custom_symbolic_trace

--- a/editing/editing/float2fake/quantisation/modulewiseconverter/__init__.py
+++ b/editing/editing/float2fake/quantisation/modulewiseconverter/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 """This package implements the abstraction to perform module-wise
 float-to-fake conversions.
 

--- a/editing/editing/float2fake/quantisation/modulewiseconverter/applicationpoint.py
+++ b/editing/editing/float2fake/quantisation/modulewiseconverter/applicationpoint.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch.fx as fx
 from typing import NamedTuple
 

--- a/editing/editing/float2fake/quantisation/modulewiseconverter/applier.py
+++ b/editing/editing/float2fake/quantisation/modulewiseconverter/applier.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import copy
 import torch.fx as fx
 

--- a/editing/editing/float2fake/quantisation/modulewiseconverter/finder.py
+++ b/editing/editing/float2fake/quantisation/modulewiseconverter/finder.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from collections import OrderedDict
 import torch.fx as fx
 from typing import List

--- a/editing/editing/float2fake/quantisation/modulewiseconverter/modulewisedescription/__init__.py
+++ b/editing/editing/float2fake/quantisation/modulewiseconverter/modulewisedescription/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .nametomodule import NameToModule
 from .nametomodule import N2MFilter, N2MFilterSpecType
 from .modulewisedescription import ModuleWiseDescription, ModuleWiseDescriptionSpecType

--- a/editing/editing/float2fake/quantisation/modulewiseconverter/modulewisedescription/modulewisedescription.py
+++ b/editing/editing/float2fake/quantisation/modulewiseconverter/modulewisedescription/modulewisedescription.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 """We build ``ModuleWiseFinder``s and ``ModuleWiseReplacer``s around this data
 structure.
 """

--- a/editing/editing/float2fake/quantisation/modulewiseconverter/modulewisedescription/nametomodule/__init__.py
+++ b/editing/editing/float2fake/quantisation/modulewiseconverter/modulewisedescription/nametomodule/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .nametomodule import NameToModule
 from .n2mfilter import N2MFilter
 from .n2mfilterspec import N2MFilterSpecType, resolve_n2mfilterspec

--- a/editing/editing/float2fake/quantisation/modulewiseconverter/modulewisedescription/nametomodule/n2mfilter.py
+++ b/editing/editing/float2fake/quantisation/modulewiseconverter/modulewisedescription/nametomodule/n2mfilter.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 """This module implements a system of functions to filter ``NameToModule``s.
 
 The system is closed with respect to comopsition, since each filter takes in

--- a/editing/editing/float2fake/quantisation/modulewiseconverter/modulewisedescription/nametomodule/n2mfilterspec.py
+++ b/editing/editing/float2fake/quantisation/modulewiseconverter/modulewisedescription/nametomodule/n2mfilterspec.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from collections import OrderedDict
 import functools
 from enum import Enum

--- a/editing/editing/float2fake/quantisation/modulewiseconverter/modulewisedescription/nametomodule/nametomodule.py
+++ b/editing/editing/float2fake/quantisation/modulewiseconverter/modulewisedescription/nametomodule/nametomodule.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 """The data structure used by ``ModuleWiseFinder``s to identify application
 points.
 """

--- a/editing/editing/float2fake/quantisation/modulewiseconverter/rewriter.py
+++ b/editing/editing/float2fake/quantisation/modulewiseconverter/rewriter.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .modulewisedescription import ModuleWiseDescription, ModuleWiseDescriptionSpecType
 from .finder import ModuleWiseFinder
 from .applier import ModuleWiseReplacer

--- a/editing/editing/float2fake/quantisation/qdescription/__init__.py
+++ b/editing/editing/float2fake/quantisation/qdescription/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 """This package implements the abstractions do described quantised modules.
 
 Apart from the canonical collection data structures, the module defines

--- a/editing/editing/float2fake/quantisation/qdescription/qalgorithm.py
+++ b/editing/editing/float2fake/quantisation/qdescription/qalgorithm.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from enum import Enum
 from typing import NamedTuple, Tuple, Dict, Union, Optional, Any
 

--- a/editing/editing/float2fake/quantisation/qdescription/qdescription.py
+++ b/editing/editing/float2fake/quantisation/qdescription/qdescription.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from enum import Enum
 from typing import NamedTuple, Tuple, Union
 

--- a/editing/editing/float2fake/quantisation/quantiserinterposer/__init__.py
+++ b/editing/editing/float2fake/quantisation/quantiserinterposer/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from collections import OrderedDict
 import copy
 import itertools

--- a/editing/editing/float2fake/quantisation/quantiserinterposer/applier.py
+++ b/editing/editing/float2fake/quantisation/quantiserinterposer/applier.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import copy
 import torch.nn as nn
 import torch.fx as fx

--- a/editing/editing/float2fake/quantisation/quantiserinterposer/finder.py
+++ b/editing/editing/float2fake/quantisation/quantiserinterposer/finder.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from quantlib.editing.editing.editors.nnmodules import NNSequentialPattern, PathGraphMatcher
 
 

--- a/editing/editing/float2fake/quantisation/weightrounder/__init__.py
+++ b/editing/editing/float2fake/quantisation/weightrounder/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Francesco Conti <f.conti@unibo.it>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from collections import OrderedDict
 from quantlib.algorithms.qalgorithms.qatalgorithms.pact.qlinears import PACTLinear, PACTConv1d, PACTConv2d, PACTConv3d
 import torch.nn as nn

--- a/editing/editing/float2fake/quantisation/weightrounder/applier.py
+++ b/editing/editing/float2fake/quantisation/weightrounder/applier.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Francesco Conti <f.conti@unibo.it>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch
 import torch.fx as fx
 

--- a/editing/editing/tests/ILSVRC12/MobileNetV1/__init__.py
+++ b/editing/editing/tests/ILSVRC12/MobileNetV1/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .preprocess import ILSVRC12MNv1Transform
 from .mobilenetv1 import MobileNetV1
 from .headrewriter import MNv1HeadRewriter

--- a/editing/editing/tests/ILSVRC12/MobileNetV1/headrewriter.py
+++ b/editing/editing/tests/ILSVRC12/MobileNetV1/headrewriter.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch
 import torch.nn as nn
 import torch.fx as fx

--- a/editing/editing/tests/ILSVRC12/MobileNetV1/preprocess.py
+++ b/editing/editing/tests/ILSVRC12/MobileNetV1/preprocess.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from ..data import ILSVRC12Transform
 
 

--- a/editing/editing/tests/ILSVRC12/MobileNetV2/__init__.py
+++ b/editing/editing/tests/ILSVRC12/MobileNetV2/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .preprocess import ILSVRC12MNv2Transform
 from .mobilenetv2 import MobileNetV2
 from .headrewriter import MNv2HeadRewriter

--- a/editing/editing/tests/ILSVRC12/MobileNetV2/headrewriter.py
+++ b/editing/editing/tests/ILSVRC12/MobileNetV2/headrewriter.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch
 import torch.nn as nn
 import torch.fx as fx

--- a/editing/editing/tests/ILSVRC12/MobileNetV2/preprocess.py
+++ b/editing/editing/tests/ILSVRC12/MobileNetV2/preprocess.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from ..data import ILSVRC12Transform
 
 

--- a/editing/editing/tests/ILSVRC12/ResNet/__init__.py
+++ b/editing/editing/tests/ILSVRC12/ResNet/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .preprocess import ILSVRC12RNTransform
 from .resnet import ResNet
 from .headrewriter import RNHeadRewriter

--- a/editing/editing/tests/ILSVRC12/ResNet/headrewriter.py
+++ b/editing/editing/tests/ILSVRC12/ResNet/headrewriter.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch
 import torch.nn as nn
 import torch.fx as fx

--- a/editing/editing/tests/ILSVRC12/ResNet/preprocess.py
+++ b/editing/editing/tests/ILSVRC12/ResNet/preprocess.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from ..data import ILSVRC12Transform
 
 

--- a/editing/editing/tests/ILSVRC12/data/__init__.py
+++ b/editing/editing/tests/ILSVRC12/data/__init__.py
@@ -1,2 +1,21 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .transforms import ILSVRC12STATS, ILSVRC12Transform
 from .dataset import get_ilsvrc12_dataset

--- a/editing/editing/tests/ILSVRC12/data/dataset.py
+++ b/editing/editing/tests/ILSVRC12/data/dataset.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import os
 import torch
 import torchvision

--- a/editing/editing/tests/ILSVRC12/data/transforms.py
+++ b/editing/editing/tests/ILSVRC12/data/transforms.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from torchvision.transforms import Resize, CenterCrop, ToTensor, Normalize
 from torchvision.transforms import Compose
 

--- a/editing/editing/tests/__init__.py
+++ b/editing/editing/tests/__init__.py
@@ -1,2 +1,21 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from . import ILSVRC12
 from . import common

--- a/editing/editing/tests/common/__init__.py
+++ b/editing/editing/tests/common/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .quantisation import apply_f2f_flow, initialise_quantisation, apply_f2t_flow
 from .evaluation import evaluate_network
 from .backend import get_directory, zip_directory

--- a/editing/editing/tests/common/backend.py
+++ b/editing/editing/tests/common/backend.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import os
 import shutil
 

--- a/editing/editing/tests/common/evaluation.py
+++ b/editing/editing/tests/common/evaluation.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from __future__ import annotations
 
 from collections import OrderedDict

--- a/editing/editing/tests/common/quantisation.py
+++ b/editing/editing/tests/common/quantisation.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import random
 import torch
 import torch.fx as fx

--- a/editing/editing/tests/test_flows.py
+++ b/editing/editing/tests/test_flows.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch
 
 from . import ILSVRC12, common

--- a/editing/graphs/__init__.py
+++ b/editing/graphs/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from . import nn
 from . import fx
 from . import lightweight as lw

--- a/editing/graphs/fx/__init__.py
+++ b/editing/graphs/fx/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 # for "non-extender" users
 from .tracing import quantlib_symbolic_trace
 # for developers and "extender" users

--- a/editing/graphs/fx/fxgraphlist.py
+++ b/editing/graphs/fx/fxgraphlist.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from __future__ import annotations
 
 import torch.nn as nn

--- a/editing/graphs/fx/fxnodes.py
+++ b/editing/graphs/fx/fxnodes.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 """Define abstractions to simplify the handling of ``fx.Node`` objects.
 
 The first functionality is being able to partition ``fx.Node``s according to

--- a/editing/graphs/fx/tracing.py
+++ b/editing/graphs/fx/tracing.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from functools import partial
 import torch.nn as nn
 import torch.fx as fx

--- a/editing/graphs/lightweight/__init__.py
+++ b/editing/graphs/lightweight/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 # for "non-extender" users
 from .traversal import quantlib_traverse
 # for developers and "extender" users

--- a/editing/graphs/lightweight/node.py
+++ b/editing/graphs/lightweight/node.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from __future__ import annotations
 
 import torch.nn as nn

--- a/editing/graphs/lightweight/traversal.py
+++ b/editing/graphs/lightweight/traversal.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from functools import partial
 import torch.nn as nn
 from typing import Type, Tuple

--- a/editing/graphs/nn/__init__.py
+++ b/editing/graphs/nn/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 # for developers and "extender" users
 from .harmonisedadd import HarmonisedAdd
 from .epstunnel     import EpsTunnel

--- a/editing/graphs/nn/epstunnel.py
+++ b/editing/graphs/nn/epstunnel.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch
 import torch.nn as nn
 

--- a/editing/graphs/nn/harmonisedadd.py
+++ b/editing/graphs/nn/harmonisedadd.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import copy
 import torch
 import torch.nn as nn

--- a/editing/graphs/nn/requant.py
+++ b/editing/graphs/nn/requant.py
@@ -49,8 +49,8 @@ class Requantisation(nn.Module):
         x = x * self.mul
         x = x + self.add
         x = torch.floor(x / self.div)  # This operation can be implemented in integer digital arithmetic as a right-shift by :math:`\log_{2}(D)` places; divisions can be avoided.
-        lo = float(self.zero)
-        hi = float(self.zero + self.n_levels - 1)
+        lo = torch.float(self.zero)
+        hi = torch.float(self.zero + self.n_levels - 1)
         x = RequantClipFn.apply(x, lo, hi)
 
         return x

--- a/editing/graphs/nn/requant.py
+++ b/editing/graphs/nn/requant.py
@@ -49,8 +49,8 @@ class Requantisation(nn.Module):
         x = x * self.mul
         x = x + self.add
         x = torch.floor(x / self.div)  # This operation can be implemented in integer digital arithmetic as a right-shift by :math:`\log_{2}(D)` places; divisions can be avoided.
-        lo = torch.float(self.zero)
-        hi = torch.float(self.zero + self.n_levels - 1)
+        lo = float(self.zero)
+        hi = float(self.zero + self.n_levels - 1)
         x = RequantClipFn.apply(x, lo, hi)
 
         return x

--- a/editing/graphs/nn/requant.py
+++ b/editing/graphs/nn/requant.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 import torch
 import torch.nn as nn
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from .aliases import UnknownType, UNKNOWN
 from .messages import quantlib_log_header, quantlib_wng_header, quantlib_err_header
 from .saver import Saver

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,2 +1,3 @@
 from .aliases import UnknownType, UNKNOWN
 from .messages import quantlib_log_header, quantlib_wng_header, quantlib_err_header
+from .saver import Saver

--- a/utils/aliases.py
+++ b/utils/aliases.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from typing import NewType
 
 

--- a/utils/messages.py
+++ b/utils/messages.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Matteo Spallanzani <spmatteo@iis.ee.ethz.ch>
+# 
+# Copyright (c) 2020-2022 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from functools import partial
 
 

--- a/utils/saver.py
+++ b/utils/saver.py
@@ -1,0 +1,51 @@
+from contextlib import contextmanager
+import typing
+from typing import Callable, Iterable, Mapping
+from torch.fx import GraphModule
+from collections import OrderedDict
+
+class Saver(object):
+    def __init__(
+        self,
+        net : GraphModule
+    ) -> None:
+        self.net = net
+
+        self._buffer_out : Mapping = OrderedDict([])
+        self._hooks : Mapping = OrderedDict([])
+        self._modules : Iterable = []
+
+    def start_saving(self):
+
+        # reinitialize all buffers
+        self._buffer_out : Mapping = OrderedDict([])
+        self._hooks : Mapping = OrderedDict([])
+        self._modules : Iterable = []
+
+        self._modules = list(self.net.named_modules())
+        
+        # define hooks
+        def get_hk(n):
+            def hk(module, input, output):
+                self._buffer_out [n] = output
+            return hk
+        
+        for i,(n,l) in enumerate(self._modules):
+            hk = get_hk(n)
+            self._hooks[n] = l.register_forward_hook(hk)
+
+    def stop_saving(self):
+        # remove hooks
+        for i,(n,l) in enumerate(self._modules):
+            self._hooks[n].remove()
+
+    def get(self, n):
+        return self._buffer_out[n]
+    
+    @contextmanager
+    def saving(self):
+        self.start_saving()
+        try:
+            yield
+        finally:
+            self.stop_saving()

--- a/utils/saver.py
+++ b/utils/saver.py
@@ -1,3 +1,22 @@
+# 
+# Author(s):
+# Francesco Conti <f.conti@unibo.it>
+# 
+# Copyright (c) 2018-2023 ETH Zurich and University of Bologna.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 from contextlib import contextmanager
 import typing
 from typing import Callable, Iterable, Mapping


### PR DESCRIPTION
-  Add RequantClipFn to enable proper ONNX export of clipping: this allows exporting proper `Clip` nodes in ONNX  instead of `Min`,`Max` symbolics.
- Add FlattenCanonicaliser to transform a few known "bad" flatten templates into a single "good" one based on `nn.Flatten`.
- Add an editor that can remove the final `EpsTunnel`, e.g., to transfer to a backend deployment tool that is not capable of interpreting the `EpsTunnel`s.
- Add `AddCalibrator` editor to harmonise `HarmonisedAdd` layers post-calibration. Before it was performed only during training.
- Add `DropoutRemover` transform to remove `nn.Dropout` layers.
- Add a `AddRequantisationMerger` to merge the requant resulting from `HarmonisedAdd` blocks with the previous ones (e.g., from regular `nn.Relu`). This can be useful, e.g., when the backend deployment tool does not support back-to-back requantisation layers.
- Fixes to DORY ONNX exporter.
- Use `_` char instead of `[`,`]` to index modules inserted by editors (makes it easier to address them in code).