### PR TITLE
OPEN: Fixes for Transformer quantization and Deeploy export

### DIFF
--- a/editing/fx/passes/pact/harmonize.py
+++ b/editing/fx/passes/pact/harmonize.py
@@ -170,7 +170,8 @@ class OpTreeReplacementPass(FxPass):
                 #now, we assume the output of the new node has the same "quant"
                 #meta properties as the output of the tree that is being
                 #replaced
-                new_node.meta['quant'] = deepcopy(tree.end_node.meta['quant'])
+                if hasattr(tree.end_node, "meta") and "quant" in tree.end_node.meta:
+                    new_node.meta['quant'] = deepcopy(tree.end_node.meta['quant'])
                 # finally, delete the nodes in the tree
                 for node in tree.nodes:
                     gm.graph.erase_node(node)


### PR DESCRIPTION
This PR fixes smaller issues with the Transformer quantization flow and network export to Deeploy.

## Added
* `skip_identity_rqs` flag for the Integerizer; this flag allows to configure whether to skip Requantshift operators whose source and image epsilon are the same. Default behaviour does not change.

## Changes
* `OpTreeReplacementPass` now doesn't require the `quant` entry in the `meta` dict of nodes, but will still copy it if it is available.

## Fixed
* `ApproximateSoftmaxPass` now returns a new instance for every call, rather than sharing the same object.