### PR TITLE
Add PACTRMSNorm and SiLU Replacement Pass

### DIFF
--- a/editing/fx/passes/pact/approximate.py
+++ b/editing/fx/passes/pact/approximate.py
@@ -74,7 +74,7 @@ class ApproximateGELUPass(SequentialPass):
         passes.append(ReplaceSequentialPatternPass(pattern, PACT_symbolic_trace, lambda x,y: PACTGELU(), f'_APPROXIMATE_GELU_PASS'))
         super().__init__(*passes, name_prefix='_APPROXIMATE_GELU_PASS')
 
-class ApproximateSiLUPass(SequentialPass):
+class ApproximateSiLUWithGELUPass(SequentialPass):
     def __init__(self, custom_trace, **kwargs):
         passes = []
         pattern = nn.Sequential(nn.SiLU())

--- a/editing/fx/passes/pact/approximate.py
+++ b/editing/fx/passes/pact/approximate.py
@@ -120,6 +120,26 @@ def embedding_replacement_fun(gm : fx.GraphModule, match : Match, n_levels: int 
 
     return new_embedding
 
+def rmsnorm_replacement_fun(custom_module, gm : fx.GraphModule, match : Match, *args, **kwargs):
+    modules = gm_modules(gm)
+    matched_modules = [modules[m.target] for k, m in match.nodes_map.items() if k.op == 'call_module'][::-1]
+    rmsnorm = matched_modules[0]
+
+    assert isinstance(rmsnorm, type(custom_module)), f"rmsnorm_replacement_fun got bad match - expected LayerNorm, got {type(rmsnorm)}"
+
+    weight = rmsnorm._parameters['weight'].clone() if rmsnorm._parameters['weight'] is not None  else torch.Tensor((1.,))
+
+    new_rmsnorm = PACTRMSNorm(rmsnorm.weight.shape, weight, rmsnorm.variance_epsilon)
+
+    return new_rmsnorm
+
+class CanonicalizeRMSNormPass(SequentialPass):
+    def __init__(self, custom_trace, custom_module, *args, **kwargs):
+        passes = []
+        pattern = nn.Sequential(custom_module)
+        passes.append(ReplaceSequentialPatternPass(pattern, custom_trace, partial(rmsnorm_replacement_fun, custom_module, *args, **kwargs), f'_CANONICALIZE_RMSNORM_PASS'))
+        super().__init__(*passes, name_prefix='_CANONICALIZE_RMSNORM_PASS')
+
 class ProtoPACTEmbedding(torch.nn.Module):
 
     def __init__(self, weights : torch.Tensor = torch.Tensor((1.,))):


### PR DESCRIPTION
This PR adds a new operator and two replacement passes that will be useful for deploying llama-based transformer models.

## Added
- A new PACT operator for the `RMSNormalization` operation from [this paper](https://arxiv.org/abs/1910.07467). As PyTorch doesn't have an RMSNorm module yet, users need to provide a custom trace and module to match with.
-  A new replacement pass in `approximate.py` to approximate SiLU modules into PACTGelu.
